### PR TITLE
Combine minutes & reports pages

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -4,9 +4,7 @@
   text: Call for Participation
 - link: /agenda
   text: Workshop Agenda
-- link: /minutes
-  text: Minutes
 - link: /position-statements
   text: Position Statements
 - link: /report
-  text: Report
+  text: Minutes & Report

--- a/minutes.html
+++ b/minutes.html
@@ -1,4 +1,0 @@
----
-permalink: /minutes
----
-<h1>Workshop Minutes</h1>

--- a/report.html
+++ b/report.html
@@ -1,4 +1,21 @@
 ---
 permalink: /report
 ---
-<h1>Workshop Report</h1>
+<h1>Workshop Minutes &amp; Report</h1>
+
+<p>
+  Minutes will be taken collaboratively by participants during the sessions using IRC.
+  Interested observers will be able to follow along in real time.
+  (Channel information will be available closer to the event.)
+  Formatted minutes will be linked here afterwards.
+</p>
+<p>
+  A summary report, possibly including recommendations,
+  will be compiled after the workshop and also included here.
+</p>
+<p>
+  See also the
+  <a href="position-statements.html">participant submissions</a>
+  and
+  <a href="agenda.html">agenda</a>.
+</p>


### PR DESCRIPTION
These will both just be links to stand-alone documents, and neither will be available until after the event.
No need to use up precious nav bar space!