### PR TITLE
Reorganize introduction / expand suggested topics

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -1,10 +1,10 @@
 - link: /
-  text: Home Page
+  text: Overview
 - link: /call-for-participation
   text: Call for Participation
 - link: /agenda
   text: Workshop Agenda
-- link: /position-statements
-  text: Position Statements
+- link: /supporting-material
+  text: Participant Submissions
 - link: /report
   text: Minutes & Report

--- a/agenda.html
+++ b/agenda.html
@@ -229,7 +229,7 @@ schedule:
   <h3 id="suggested-reading">Suggested Reading</h3>
   <p>
     If you can, please review the
-    <a href="position-statements">participant position statements and other submissions</a>
+    <a href="supporting-material">participant position statements and other supporting material</a>
     before the meeting.
   </p>
 </article>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -243,16 +243,23 @@ a.ref {
 
 ul {
   list-style: square;
+  list-style: "❑ ";
   margin-left: 0;
   padding-left: 1em;
+}
+ul ul {
+  list-style: circle;
+  list-style: "➢ ";
+  margin: 0.5rem 0 1.5rem;
 }
 
 blockquote {
   margin-left: 1em;
 }
 
-.main {
-  margin-top: 3rem;
+main {
+  margin-top: 2rem;
+  max-width: 42rem;
 }
 
 dd {

--- a/call-for-participation.html
+++ b/call-for-participation.html
@@ -9,28 +9,11 @@ permalink: /call-for-participation
   Web.
 </p>
 
-<p>The scope includes:</p>
-<i>The current list of workshop topics, subject to change, being discussed
-  are:</i>
+<p>The scope of the workshop and potential topics are outlined
+  <a href="/#scope">on the overview page</a>.
+  However, participants are welcome to suggest other topics within the scope.
+</p>
 
-<ul>
-  <li>a native map viewer, like that provided for video content</li>
-  <li>standards for how such a map widget might use map services links</li>
-  <li>
-    Integration / relationship of maps and location with other browser APIs,
-    e.g. geo-video, geolocation API, forms, SVG
-  </li>
-  <li>
-    semantic rendering of spatial “things” to support spatial accessibility
-  </li>
-  <li>standardized browser elements and APIs</li>
-  <li>crawlers, indexes and search to support discovery of Web resources</li>
-  <li>CSS styling of maps and map features</li>
-  <li>Map feature creation / forms</li>
-  <li>federated map services with linking</li>
-  <li>accessibility of browser maps</li>
-  <li>security of browser-based maps</li>
-</ul>
 <p>
   The workshop will be two days of presentation and discussions, followed by one
   day of hands-on hacking, allowing participants to go in depth into proposals

--- a/index.html
+++ b/index.html
@@ -2,66 +2,128 @@
 permalink: "/"
 ---
 
-<h2>Introduction</h2>
+<h2 id="introduction">Introduction</h2>
 <p>
-  Maps are a facet of our daily lives. From deciding what route to take to work,
-  to vacation planning, to researching the effects of climate change, the Web
-  provides maps that guide our decisions and inform our world view. The rise of
-  powerful mobile processors and access to open and free high resolution spatial
-  information yields the opportunity to augment the access of every citizen to
-  location information.
+  Maps are a facet of our daily lives.
+  The web (and other internet-connected applications)
+  have made maps more personal and more pervasive.
+  From deciding what route to take to work,
+  to vacation planning, to researching the effects of climate change,
+  online maps guide our decisions and inform our world view.
+</p>
+<p>
+  Maps on the web have the potential to empower individuals,
+  connecting our physical environment
+  to online information and applications.
+  But that hyperconnectivity comes with risks:
+  that people's movements may be tracked,
+  or that their lives and livelihoods may become dependent
+  on closed, proprietary data and services.
+</p>
+<p>
+  This workshop brings together experts in
+  geographic standards and web map data services,
+  web mapping client tools and applications,
+  and web platform standards and browser development,
+  for 3 days of exploration of the potential of maps for the web.
+</p>
+
+<h2 id="topics">Scope and Potential Topics</h2>
+
+<p>
+  The workshop is specifically about map content displayed to end users —
+  usually in an explorable, interactive viewer —
+  within the context of websites and other applications built using the web platform.
+  Broader uses of internet-connected geographic data or spatial metadata
+  are only in scope so far as they share technologies and impacts with web maps.
 </p>
 
 <p>
-  The unprecedented growth in map content is driven by factors such as advances
-  in mobile computing, and a broad and growing recognition of the importance of
-  the location of and visualization of spatial information in decision making.
-  We see evidence of this in the growth of world wide contributions to projects
-  such as Open Street Map, as well as in the public investments by governments
-  in open spatial data infrastructures.
-</p>
-
-<p>
-  From a standards perspective however, there is an important story to tell. The
-  geospatial information community has, for more than two decades, developed
-  standards and applications that support and secure the infrastructural
-  investments that society has made, and is making, in geospatial content.
-  Certainly, lessons about the ingredients for successful geospatial information
-  standards have been learned, some the hard way.
-</p>
-
-<p>
-  World wide, spatial data infrastructures and Web map content are accessed
-  through services that implement OGC standards such as the Web Map Service
-  (WMS), Web Feature Service (WFS), Catalog Services, Web Map Tile Service
-  (WMTS) and other standards. There is a distinct trend towards JSON-ified
-  hypermedia API versions of all of these legacy standards, making this content
-  accessible to Web developers in a simplified fashion. The recently published
-  <a href="https://www.opengeospatial.org/standards/ogcapi-features"
-    >OGC API - Features</a
-  >
-  standard is a response, in part, to the growing popularity of Web APIs. And
-  yet, there are few dedicated Web platform standards to support and unify this
-  growth. The support the Web platform offers is purely that of a scripted
-  rendering platform, which results in a suboptimal use of resources by society
-  by keeping the bar to using map content too high.
-</p>
-
-<p>
-  This workshop is dedicated to uncovering how the evolving Web platform could
-  help society by lowering barriers to Web mapping, and by unifying the
-  burgeoning universe of standard and non-yet-standard spatial information.
-  Topics of interest include:
+  The final <a href="agenda">agenda</a> of talks and workshop sessions
+  will be determined based on responses to the
+  <a href="call-for-participation">call for participation</a>.
+  However, the following areas are of particular interest:
 </p>
 
 <ul>
-  <li>a native map viewer, like that provided for video content</li>
-  <li>standards for how such a map widget might use map services links</li>
   <li>
-    semantic rendering of spatial “things” to support spatial accessibility
+    Adding a native map viewer for the web platform, 
+    similar to how HTML <code>&ltvideo&gt</code> was added for video content;
+    including
+    <ul>
+      <li>essential, possible, or impractical user-focused
+        features and capabilities of a built-in web map viewer</li>
+      <li>architecture for defining a map viewer in markup</li>
+      <li>new scripting APIs for web authors to enhance map viewers</li>
+      <li>CSS integration for styling maps and map features</li>
+      <li>other integration / relationship of maps with existing browser APIs
+        (e.g., geolocation API, geo/map URL protocols,
+          image maps, SVG and canvas graphics)
+      </li>
+      <li>other web platform applications
+        for map-viewer display and interaction patterns</li>
+    </ul>
   </li>
-  <li>standardized browser elements and APIs</li>
-  <li>crawlers, indexes and search to support discovery of Web resources</li>
-  <li>map feature styling, accessibility, creation / forms</li>
-  <li>federated map services with linking</li>
+  <li>
+    Standards for how a browser-based map viewer
+    could fetch data from map services
+    and how that data should be formatted;
+    including
+    <ul>
+      <li>benefits and limitations of existing map data sources
+        for web use</li>
+      <li>working with offline cached map data</li>
+      <li>integrating geographic data and (hyper)text annotations
+        or other semantic information about spatial things</li>
+      <li>working with map data in different projections
+        or coordinate reference systems</li>
+      <li>federating map services with links between providers</li>
+      <li>supporting discovery of Web-based geospatial resources by
+        crawlers, indexes, and search engines
+      </li>
+    </ul>
+  <li>
+    Creating accessible and international web map experiences;
+    including
+    <ul>
+      <li>best-practice interaction patterns
+        for manipulating web (and other interactive/slippy) maps
+        using different input methods (mouse, touch, keyboard, etc.)</li>
+      <li>communicating spatial information through non-visual technologies</li>
+      <li>personalization of map viewer display and capabilities</li>
+      <li>using spatial information to enhance accessibility
+        in the physical environment</li>
+      <li>linguistic and cultural considerations
+        when internationalizing map data
+        and map-viewer interaction patterns</li>
+    </ul>
+  </li>
+  <li>
+    Limiting privacy and security impacts of a more geo-enhanced web;
+    including
+    <ul>
+      <li>identifying both obvious and indirect ways malicious actors
+        could misuse web maps to expose personal data
+        or fingerprintable patterns
+      </li>
+      <li>
+        creating options to support user-friendly functionality
+        while limiting exposure of personal location and geographic data
+        (e.g., allowing a user to do a one-time location-aware search without
+          granting ongoing permission for location tracking;
+          sandboxing personalized map views and interactions
+          from web map services providing the underlying data)
+      </li>
+      <li>communication of the impacts and risks of sharing location data</li>
+      <li>validation and verification of map data sources,
+        and avoiding misinformation</li>
+      <li>cross-origin security risks when integrating map data sources
+        (some of which may be personalized,
+        or contain confidential business information)
+      </li>
+    </ul>
+  </li>
 </ul>
+
+<p>See the <a href="call-for-participation">call for participation</a>
+  for how to get involved, or to suggest additional topics.</p>

--- a/position-statements.html
+++ b/position-statements.html
@@ -1,6 +1,0 @@
----
-permalink: /position-statements
----
-<h1>Position Statements</h1>
-<p>Canada Centre for Mapping and Earth Observation</p>
-<p>More</p>

--- a/report.html
+++ b/report.html
@@ -16,7 +16,7 @@ permalink: /report
 </p>
 <p>
   See also the
-  <a href="position-statements">participant submissions</a>
+  <a href="supporting-material#position-statements">participant submissions</a>
   and
   <a href="agenda">agenda</a>.
 </p>

--- a/supporting-material.html
+++ b/supporting-material.html
@@ -1,0 +1,55 @@
+---
+permalink: /supporting-material
+---
+<h1>Participant Submissions & Other Supporting Material</h1>
+
+<p>
+  Participants are invited to submit summaries of their projects and priorities,
+  for review by others before the event.
+  See the <a href="call-for-participation">call for participation</a> for more.
+</p>
+
+<h2 id="background">Background</h2>
+
+<p>
+  The unprecedented growth in web map content is driven by factors such as advances
+  in mobile computing, and a broad and growing recognition of the importance of
+  the location of and visualization of spatial information in decision making.
+  We see evidence of this in the growth of world wide contributions to projects
+  such as Open Street Map, as well as in the public investments by governments
+  in open spatial data infrastructures.
+</p>
+<p>
+  From a standards perspective, the story of web maps is mixed.
+  The geospatial information community has, for more than two decades, developed
+  standards and applications that support and secure the infrastructural
+  investments that society has made, and is making, in geospatial content.
+  Certainly, lessons about the ingredients for successful geospatial information
+  standards have been learned, some the hard way.
+</p>
+<p>
+  World wide, spatial data infrastructures and Web map content are accessed
+  through services that implement OGC standards such as the Web Map Service
+  (WMS), Web Feature Service (WFS), Catalog Services, Web Map Tile Service
+  (WMTS) and other standards. There is a distinct trend towards JSON-ified
+  hypermedia API versions of all of these legacy standards, making this content
+  accessible to Web developers in a simplified fashion. The recently published
+  <a href="https://www.opengeospatial.org/standards/ogcapi-features"
+    >OGC API - Features</a
+  >
+  standard is a response, in part, to the growing popularity of Web APIs. And
+  yet, there are few dedicated Web platform standards to support and unify this
+  growth. The support the Web platform offers is purely that of a scripted
+  rendering platform, which results in a suboptimal use of resources by society
+  by keeping the bar to using map content too high.
+</p>
+
+<p>
+  more…
+</p>
+
+<h2 id="position-statements">Participant Position Statements</h2>
+
+<h2 id="explainers">Proposals and Explainers</h2>
+
+<h2 id="projects">Related Projects</h2>


### PR DESCRIPTION
Note: I'm going to merge this right away, because it's easier to review copy on the [built webpage](https://maps4html.github.io/Maps4HTML-Workshop-2020/) than in the source code! But I'm filing it as a PR so I can tag suggested reviewers & so you can look at the changes if you like.

I still have some additional edits I want to make to the CFP itself, to expand on the types of position statements / proposals we're interested in. But I think I've covered the requests for more detailed scope/topics — let me know if you disagree!

cc @wseltzer
Related to #10, #11, #12

Summary of changes:

- Shorten / rewrite the introduction
- Expand the list of possible topics in the introduction
  with more specific examples, grouped into themes
- Remove the repeated topics list on the CFP,
  instead linking back to the overview page
- Move background on standards efforts
  to the participant submissions / supporting material page
- Rename the position-statements file to
  supporting-material to reflect it's broader scope
- Style tweaks for nested lists & long pages