### PR TITLE
Redraft the Call for Participation

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -186,7 +186,6 @@ a.ref {
 }
 
 .menu {
-  background: #005a9c;
   font-size: 1rem;
   margin: 0 0 2em;
 }
@@ -204,11 +203,16 @@ a.ref {
   padding: 0;
 }
 
-.menu li + li a {
-  border-left: 2px solid #fff;
+.menu li {
+  margin: 0;
+}
+
+.menu li + li {
+  margin-left: 2px;
 }
 
 .menu a {
+  background: #005a9c;
   color: #eee;
   display: block;
   font-size: .95rem;
@@ -228,6 +232,10 @@ a.ref {
   background: #111;
   color: #fff;
 }
+.menu a:focus {
+  outline: dashed 2px;
+  outline-offset: -4px;
+}
 
 .menu a:active {
   opacity: .75;
@@ -243,7 +251,9 @@ a.ref {
 
 ul {
   list-style: square;
-  list-style: "❑ ";
+  list-style: "✯ ";
+}
+ul, ol {
   margin-left: 0;
   padding-left: 1em;
 }
@@ -251,6 +261,12 @@ ul ul {
   list-style: circle;
   list-style: "➢ ";
   margin: 0.5rem 0 1.5rem;
+}
+li {
+  margin-bottom: 0.5rem;
+}
+li li {
+  margin-bottom: 0;
 }
 
 blockquote {
@@ -314,13 +330,8 @@ address {
     display: block;
   }
 
-  .menu li + li a {
-    border-top: 2px solid #fff;
-    border-left: 0;
-  }
-
-  .menu li + li a {
-    margin-left: 0;
+  .menu li + li {
+    margin: 2px 0 0;
   }
 
   .graphic {

--- a/call-for-participation.html
+++ b/call-for-participation.html
@@ -4,111 +4,303 @@ permalink: /call-for-participation
 
 <h1>Call For Participation</h1>
 <p>
-  This will be a three day workshop that brings together people with an interest
-  in the future of Web standards relating to maps and spatial information on the
-  Web.
+  The W3C Workshop on Maps for the Web
+  will be a three day meeting of developers, cartographers, policy makers, and
+  other people with an interest in the future of Web standards
+  relating to use of spatial information to display maps on the Web.
 </p>
 
 <p>The scope of the workshop and potential topics are outlined
-  <a href="/#scope">on the overview page</a>.
+  <a href="./#scope">on the overview page</a>.
   However, participants are welcome to suggest other topics within the scope.
 </p>
 
 <p>
-  The workshop will be two days of presentation and discussions, followed by one
-  day of hands-on hacking, allowing participants to go in depth into proposals
-  for further collaboration.
+  The workshop will be two days of presentation and discussions,
+  followed by one day of hands-on hacking and demonstrations,
+  allowing participants to go in depth and spark collaboration.
+  The workshop language is English.
 </p>
 
 <p>
   The objective of the workshop is to establish a common vision among
-  participants of how the Web platform could evolve to support accessible maps
-  and spatial information.
+  participants of how the Web platform could evolve to support
+  map-based Web experiences that embody best practices for Web users and website authors,
+  while making use of standardized geographic and spatial data sources.
 </p>
 
-<h2>How can I participate?</h2>
+<h2 id="how-to-participate">How can I participate?</h2>
+
 <p>
-  Attendance is free for all invited participants and is open to the public,
-  whether or not W3C members.
+  You can request to participate in the workshop in one or more ways:
+</p>
+<ul>
+  <li>Attending the workshop in person and participating in the discussions.</li>
+  <li>Attending the workshop via videoconference.
+    (To be confirmed, subject to technical support.)
+  </li>
+  <li>Making a <a href="#talk-proposals">presentation</a> (15 minutes)
+    or lightning talk (&lt;5 minutes),
+    or participating in a panel Q&A session
+    to introduce a topic for discussion.
+  </li>
+  <li>Leading a <a href="#hack-day-proposals">hack-day session</a>
+    to engage new contributors to an open-source Web map project
+    or teach other developers how to use a Web mapping tool or map data source.
+  </li>
+  <li>Submitting a written <a href="#position-statements">position statement</a>
+    in advance of the workshop
+    (as an individual or on behalf of an organization).
+  </li>
+</ul>
+
+<p>
+  If you wish to attend, please fill out
+  <a class="todo" title="Link to form when available">the application form</a>.
+  The application form asks several questions about your background and
+  ideas; please give these questions serious thought.
 </p>
 <p>
-  If you wish to express interest in attending, please fill out the application
-  form. The application form asks several questions about your background and
-  ideas; please give these questions serious thought. In addition to the
-  application form, you are encouraged to submit a presentation topic in the
-  form of a position statement.
+  If you wish to suggest a talk or demo/hack session,
+  or to contribute a written position statement,
+  please also send an email to the programming committee,
+  with details as described below for
+  <a href="#talk-proposals">talks</a>,
+  <a href="#hack-day-proposals">demos and hack day projects</a>,
+  or <a href="#positions-statements">written statements</a>.
+</p>
+
+<p>
+  Attendance is free for all invited participants.
+  Anyone may ask to participate,
+  whether or not they represent a W3C member organization.
 </p>
 <p>
   Because the venue has limited space, you must receive an acceptance email in
   order to attend. You might wish to defer making non-refundable travel
-  arrangements until you receive an invitation. Be sure to keep an eye on these
-  important dates.
+  arrangements until you receive an invitation.
+  Please review the <a href="#important-dates">important dates</a>.
 </p>
 <p>
   Our aim is to get diverse attendance from a variety of individuals with
-  different backgrounds and experiences including Web map, Web standards and
-  browser developers, product owners/managers, business development, corporate
-  strategy and innovation from the various industries and sectors that will be
-  the future of transportation:
+  different backgrounds and experiences including
+  geospatial information experts,
+  Web map tool developers,
+  Web standards and browser developers,
+  website developers who specialize in mapping or geographic data visualization,
+  online map services product owners/managers,
+  and
+  business development, corporate strategy and innovation
+  from the various industries and sectors that create or use online map data.
+</p>
+<p>
+  We do not currently have funding to subsidize travel costs of participants,
+  but we are open to organizations that wish to <a href="sponsorship">sponsor</a>
+  the participation of individual contributors.
+  If you need sponsorship to participate in person,
+  please indicate that on the application form
+  and the programming committee will contact you if funding becomes available.
 </p>
 
 <h2 id="important-dates">Important Dates</h2>
-<p>Call-for-participation open: February 14th 2020</p>
-<p>Application and position statement deadline: April 3rd 2020</p>
-<p>Acceptance notifications: April 17th 2020</p>
-<p>Program announcement: May 1st 2020</p>
-<p>Workshop held: June 15th to 17th 2020</p>
+<style>
+  .important-dates-table {
+    table-layout: fixed;
+    border: solid AliceBlue;
+    border-spacing: 0;
+  }
+  .important-dates-table tr:nth-of-type(even) {
+    background: AliceBlue;
+  }
+  .important-dates-table th,
+  .important-dates-table td {
+    vertical-align: baseline;
+    padding: 0.3em;
+  }
+  .important-dates-table th {
+    text-align: left;
+  }
+  .important-dates-table td {
+    width: 10em;
+  }
+</style>
+<table class="important-dates-table">
+<tr><th>Call for participation open:</th><td>February 21st 2020</td></tr>
+<tr><th>Application and session suggestion deadline:</th><td>April 3rd 2020</td></tr>
+<tr><th>Acceptance notifications:</th><td>April 17th 2020</td></tr>
+<tr><th>Program announcement:</th><td>May 1st 2020</td></tr>
+<tr><th>Final deadline to submit written position statements
+  and presentation slides/handouts:</th><td>June 1st 2020</td></tr>
+<tr><th>Workshop held:</th><td>June 15th to 17th 2020</td></tr>
+</table>
 
-<h2>How can I suggest a presentation?</h2>
+<h2 id="talk-proposals">How can I suggest a presentation or panel session?</h2>
 <p>
   This is a workshop, not a conference, and any presentations will be short,
   with topics suggested by submissions and decided by the chairs and program
   committee. Our goal is to actively discuss topics, not to watch presentations.
 </p>
 <p>
-  In order to best facilitate informed discussion, we encourage attendees to
-  read the accepted topics prior to attending the workshop.
+  In order to best facilitate informed discussion,
+  we encourage attendees to read the accepted topics
+  prior to attending the workshop.
+  Therefore, presenters should also submit written position statements
+  or other material (e.g., slide decks) in advance of the event.
 </p>
 <p>
-  If you wish to present on a topic, you should submit a position statement by
-  the deadline (see <a href="#important-dates">important dates</a>). Our program
-  committee will review the input provided, and select the most relevant topics
-  and perspectives.
+  If you wish to present on a topic,
+  please <a
+   href="#programming-committee">email the programming committee</a>
+   a summary of your proposal, by the application deadline
+  (see <a href="#important-dates">important dates</a>).
 </p>
+<p>
+  A good talk proposal should be concise (fewer than 600 words)
+  and include the following information:
+</p>
+<ol>
+  <li>Who would be presenting.
+  </li>
+  <li>A short title or topic statement for the presentation.</li>
+  <li>Whether you think this topic would be best served as
+    a full (15 minute) presentation, a lightning talk, or a Q&A panel.
+  </li>
+  <li>Which of the <a href="./#topics">suggested topics</a>
+    your presentation covers;
+    or, for a new topic, how it relates to the <a href="./#scope">workshop scope</a>.
+  </li>
+  <li>What unique information, experience, or perspectives
+    you would provide.
+  </li>
+</ol>
+<p>
+  All suggested presenters should also fill out
+  the <a class="todo" href="#how-to-participate">attendee application form</a>.
+  Information from the form (including affiliations and biography or background)
+  will be considered part of the proposal
+  and may be included on the workshop website,
+  linked from the final talk description in the agenda.
+</p>
+<p>
+  Our program committee will review the proposals and other application information
+  to select the most relevant topics and diverse perspectives.
+  If there are multiple submissions on similar topics,
+  the committee may suggest modifying your proposal
+  to focus on a unique aspect, or to shorten it for a lightning talk.
+  Alternatively, multiple speakers on a single topic
+  may be combined into a moderated panel discussion.
+</p>
+<p>
+  Presenters are expected to provide copies of their slides
+  or other relevant material in advance of the workshop
+  (see <a href="#important-dates">important dates</a>);
+  these will also be published so that other participants might review them.
+</p>
+
+<h2 id="hack-day-proposals">How can I suggest a hack day project or demo?</h2>
+<p>
+  The hack day is intended to spark new collaboration opportunities
+  between workshop participants on web map projects.
+  Hack day sessions can focus on solving specific software problems,
+  gathering feedback potential users of a software tool or dataset,
+  or building new demo projects with those tools and data.
+</p>
+<p>
+  Hack day sessions can be proposed by sending an
+  <a
+  href="#programming-committee">email to the programming committee</a>
+  with a summary of your proposal, by the application deadline
+ (see <a href="#important-dates">important dates</a>).
+</p>
+<p>
+  A good hack session proposal should be concise (fewer than 600 words)
+  and include the following information:
+</p>
+<ol>
+  <li>Who would be leading the session.</li>
+  <li>A short title or topic statement for the session.</li>
+  <li>What web map tools, geographic data sources, or other projects
+    you'd be working with.
+  </li>
+  <li>How many participants you think you could effectively work with.</li>
+  <li>How much background experience session participants should have.</li>
+  <li>How long of a session is appropriate: 90 minutes, half day, or full day.</li>
+  <li>What your expected goals or outcomes for the session are.</li>
+</ol>
+<p>
+  Hack day sessions should not be commercial sales pitches!
+  If your session would include the use of a commercial tool or data source,
+  please emphasize how it would focus on the use of open source
+  or standardized tools or data as well.
+</p>
+<p>
+  Because our venue space is limited,
+  the program committee will review proposals with a focus
+  on providing a set of sessions and projects that will be of interest
+  to a wide variety of workshop participants.
+</p>
+
+
+<h2 id="position-statements">How can I provide a written position statement?</h2>
+<p>
+  Written position statements allow you or your organization
+  to formally express your priorities or concerns
+  with respect to the standardization of maps for the Web.
+  They also allow all workshop participants
+  to identify, in advance, areas of consensus or disagreement
+  for discussion during the meeting.
+</p>
+<p>
+  Statements will be posted on the workshop website,
+  and must be submitted by
+  <a
+  href="#programming-committee">email to the programming committee</a>,
+  by the deadline for written submissions
+ (see <a href="#important-dates">important dates</a>).
+</p>
+<p>
+  A good position statement should be between 200 and 1000 words,
+  focus on the <a href="./#scope">scope of the workshop</a>,
+  and should include:
+</p>
+
+<ol>
+  <li>A brief overview of your experience or background, as it relates to Web maps.</li>
+  <li>Which aspects of Web maps you think would benefit (or not) from standardization,
+    and why.
+  </li>
+  <li>Any specific use cases or requirements you have for standardized Web maps.</li>
+  <li>Examples of best practices you think should be followed
+    (or worst practices that should be avoided).
+  </li>
+  <li>Links to related supporting resources:
+    standards, research, reports, explainers, software projects, or datasets.
+  </li>
+</ol>
 
 <p>
-  A good position statement should be a few paragraphs long and should include:
+  Position statements should focus on technical issues (what should be standardized),
+  not the standardization process.
 </p>
 
-<ul>
-  <li>Submissions should be between 200 and 1000 words.</li>
-  <li>Your background in the main topic areas of the workshop.</li>
-  <li>Which topic you would like to lead discussion on.</li>
-  <li>Links to related supporting resources.</li>
-  <li>
-    Any other topics you think the workshop should cover in order to be
-    effective.
-  </li>
-  <li>
-    A focus on technical issues, not process or platform preference. We plan to
-    talk about the what, not the how.
-  </li>
-  <li>
-    Position statements must be in English, preferably in HTML or plain-text
-    format. You may include multiple topics, but we ask that each person submit
-    only a single coherent position statement. The input provided at
-    registration time (e.g., bio, goals, interests) will be published and linked
-    to from this workshop page.
-  </li>
-</ul>
 
+<h2 id="programming-committee">Program Committee</h2>
+
+<p>Please send all submissions or questions about the agenda to the committee:</p>
+<a href="mailto:public-maps-workshop-pc@w3.org">public-maps-workshop-pc@w3.org</a>
 <p>
-  Please email statements to the program committee at
-  <a href="mailto:public-maps-workshop-pc@w3.org">public-maps-workshop-pc@w3.org</a>
+  Please note that this is a
+<a href="https://lists.w3.org/Archives/Public/public-maps-workshop-pc/">publicly archived</a> mailing list;
+you will need to respond to a verification email before your message is posted to the committee.
+</p>
+<p>
+  Proposals, presentations, and position statements must be in English.
+  (You may include your own translations, but these will be considered unofficial.)
+  Written material should be in HTML or plain-text format,
+  although PDF is also acceptable for talk slides or position statements.
 </p>
 
-<h2>Program Committee</h2>
-<p>Chairs</p>
+<h3>Committee chairs</h3>
 <ul>
   <li>Ted Guild, W3C</li>
   <li>Mike Smith, W3C</li>  
@@ -116,7 +308,7 @@ permalink: /call-for-participation
   <li>Peter Rushforth, Natural Resources Canada</li>
 </ul>
 
-<p>Committee members</p>
+<h3>Committee members</h3>
 
 <ul>
   <li>Ryan Ahola, Natural Resources Canada</li>

--- a/index.html
+++ b/index.html
@@ -28,15 +28,23 @@ permalink: "/"
   for 3 days of exploration of the potential of maps for the Web.
 </p>
 
-<h2 id="topics">Scope and Potential Topics</h2>
+<h2 id="scope">Scope of the Workshop</h2>
 
 <p>
-  The workshop is specifically about map content displayed to end users —
+  The workshop is specifically about geographic map content displayed to end users —
   usually in an explorable, interactive viewer —
   within the context of websites and other applications built using the Web platform.
+  This includes how the map data is served to the web application,
+  how it is embedded or manipulated by the website author,
+  how the result is displayed to the website visitor by the web browser,
+  and how that end user interacts with or makes use of the information in the map.
+</p>
+<p>
   Broader uses of internet-connected geographic data or spatial metadata
   are only in scope so far as they share technologies and impacts with Web maps.
 </p>
+
+<h2 id="topics">Potential Topics</h2>
 
 <p>
   The final <a href="agenda">agenda</a> of talks and workshop sessions


### PR DESCRIPTION
Again, I'm going to merge immediately so you can review from the [live website](https://maps4html.github.io/Maps4HTML-Workshop-2020/call-for-participation).

But either way, to all program committee members, please review the final text before our Thursday call!

Especially to Ted and Mike, I hope my changes to the description of a "good position statement" aren't problematic.

Major changes:

- Separate out talk/session proposals from written position statements,
  with different requirements (and deadlines) for each.
- Add in a section about hack day proposals.
- Add in a warning that talk slides will be expected in advance.
- Mention the possibility of remote participation,
  and of travel support if sponsorship becomes available.
- Edit the overview page (again)
  to be a little more specific about the overall scope,
  separate from the suggested topics.

Also, some style tweaks for lists.

Note the "todo" link to the actual attendee application form.

@tguild If you're able to set up a draft version of that form for us to review on WBS, that would be great. I don't have access to anything that gave me a template for workshop registration, so I'm not sure how different it will be from the community group F2F registration template that I could work with.