### PR TITLE
Agenda import

### DIFF
--- a/agenda.html
+++ b/agenda.html
@@ -6,186 +6,153 @@ description: >-
   the W3C/OGC Joint Workshop Series on Maps for the Web, September & October 2020.
 layout: default
 schedule:
-
   - title: "21 September"
     agenda:
-       - title: "State of Web Map widgets today"
-       type: plenary
-       goals:       
-       details:
-       talks:
-          title: "Introduction/Welcome, Why maps for the web"
-          speaker: Peter Rushforth
-	  title: "User Cases"
-	  speaker:Amelia Bellamy-Royds
-	  title: "User Research on Maps in HTML"
-	  speaker: Terence Eden
-	  title: Geomoose
-	  speaker: Dan Little
-
-       type: panel
-       details:
-          title: Maps in HTML
-	  
+      - title: "State of Web Map widgets today"
+        type: plenary
+        goals:
+        details:
+          - Talks:
+            - Introduction/Welcome, Why maps for the web
+              <span>Peter Rushforth</span>
+            - User Cases
+              <span>Amelia Bellamy-Royds</span>
+            - User Research on Maps in HTML
+              <span>Terence Eden</span>
+            - Geomoose
+              <span>Dan Little</span>
+      - title: Maps in HTML
+        type: panel
   - title: "22 September"
     agenda:
-       - title: "State of map data & server standards today"
-       type: plenary
-       details:
-       goals:
-       talks:
-          title: OGC APIs for web use
-          speaker: Gobe Hobona
-	  title: pygeoapi
-	  speaker: Tom Angelos Francesco
-	  title: Connection of the MapML initiative with OGC standards such as the new OGC API Tiles candidate or the old WMS.
-	  speaker: Joan Masó
-	  title: Limitations to use of OGC services
-	  speaker: Jonathan Moules
-       type: panel
-       details:
-          title: "Government geospatial data providers & the web"
-
+      - title: "State of map data & server standards today"
+        type: plenary
+        goals:
+        details:
+          - Talks:
+            - OGC APIs for web use
+              <span>Gobe Hobona</span>
+            - pygeoapi
+              <span>Tom Angelos Francesco</span>
+            - Connection of the MapML initiative with OGC standards such as the new OGC API Tiles candidate or the old WMS
+              <span>Joan Masó</span>
+            - Limitations to use of OGC services
+              <span>Jonathan Moules</span>
+      - title: "Government geospatial data providers & the web"
+        type: panel
   - title: "23 September"
     agenda:
-       - title: "Native map viewer for the Web platform"
-       type:
-       details:
-       goals:
-       talks:
-          title: "Extending the web"
-          speaker: Brian Kardell
-          title: The MapML proposal
-          speaker: Peter Rushforth
-          title: "Bocoup's Review of the MapML Proposal"
-          speaker: Simon Pieters
-          title: SVGMap and Distributed Web Maps 
-          speaker: Satoru Takagi
-          title: 
-          speaker: 
-       type: breakout
-       details:
-          title: "The <map> and <layer> speculative polyfill (MapML)"	  
-       type: panel
-       details:
-          title: "Web Maps Use Cases and Challenges" 
-
+      - title: "Native map viewer for the Web platform"
+        type: plenary
+        details:
+          - Talks:
+            - Extending the web
+              <span>Brian Kardell</span>
+            - The MapML proposal
+              <span>Peter Rushforth</span>
+            - Bocoup's Review of the MapML Proposal
+              <span>Simon Pieters</span>
+            - SVGMap and Distributed Web Maps
+              <span>Satoru Takagi</span>
+      - title: "The &lt;map&gt; and &lt;layer&gt; speculative polyfill (MapML)"
+        type: breakout
+      - title: "Web Maps Use Cases and Challenges"
+        type: panel
   - title: "24 September"
     agenda:
-       - title: "Internationalized Web maps"
-       type: plenary
-       details:
-       goals:
-       talks:
-          title: Multilingual text rendering
-          speaker: Brandon Liu
-       - title: "Privacy and Security of web maps"
-       type: plenary
-       details:
-       goals:
-       talks:
-          title: Fuzzy geolocation 
-          speaker: Thijs Brentjens
-       - title: "Creating accessible Web map widgets"
-       type: plenary
-       details:
-       goals:
-       talks:
-          title: UI patterns in existing web map widgets
-          speaker: Nic Chan
-          title: Audio maps
-          speaker: Brandon Biggs
-       type: panel
-       details:
-          title: Creating accessible Web map widgets
-       type: breakout
-       details:
-          title: Building Cross-Sensory Maps Using Audiom,,
-
-    - title: "28 September"
+      - title: "Internationalized Web maps"
+        type: plenary
+        goals:
+        details:
+          - Talks:
+            - Multilingual text rendering
+              <span>Brandon Liu</span>
+      - title: "Privacy and Security of web maps"
+        type: plenary
+        details:
+          - Talks:
+            - Fuzzy geolocation
+              <span>Thijs Brentjens</span>
+      - title: "Creating accessible Web map widgets"
+        type: plenary
+        details:
+          - Talks:
+            - UI patterns in existing web map widgets
+              <span>Nic Chan</span>
+            - Audio maps
+              <span>Brandon Biggs</span>
+      - title: Creating accessible Web map widgets
+        type: panel
+      - title: Building Cross-Sensory Maps Using Audiom
+        type: breakout
+  - title: "28 September"
     agenda:
-       - title: "Web Maps for Real-World Accessibility"
-       type: plenary
-       details:
-       goals:
-       talks:
-          title: Physical accessibility data in maps 
-          speaker: Sebastian Zappe
-          title: Indoor maps
-          speaker: "Claudia Loitsch & Julian Striegl"
-      type: panel
-       details:
-          title: "Web Maps for Real-World Accessibility"	  
-       - title: "Building better map data services/formats for web use"
-       type: plenary
-       details:
-       goals:
-       talks:
-          title: Advanced Analytics Software Project for Geospatial Data
-          speaker: Nicolas Rafael Palomino
-          title: Map Compositions format
-          speaker: Karel Charvat
-       type: breakout
-       details:
-          title: Map Whiteboard and format
-       type: plenary
-       details:
-       goals:
-       talks:
-          title: Embedding rendering & behavior configuration in map data
-          speaker: Danielle Dupuy
-	  
+      - title: "Web Maps for Real-World Accessibility"
+        type: plenary
+        details:
+          - Talks:
+            - Physical accessibility data in maps
+              <span>Sebastian Zappe</span>
+            - Indoor maps
+              <span>Claudia Loitsch & Julian Striegl</span>
+      - title: "Web Maps for Real-World Accessibility"
+        type: panel
+      - title: "Building better map data services/formats for web use"
+        type: plenary
+        details:
+          - Talks:
+            - Advanced Analytics Software Project for Geospatial Data
+              <span>Nicolas Rafael Palomino</span>
+            - Map Compositions format
+              <span>Karel Charvat</span>
+      - title: Map Whiteboard and format
+        type: breakout
+      - title: "MISSING TITLE"
+        type: plenary
+        details:
+          - Talks:
+            - Embedding rendering & behavior configuration in map data
+              <span>Danielle Dupuy</span>
   - title: "29 September"
     agenda:
-       - title: "Advanced web graphics for mapping"
-       type:
-       details:
-       goals:
-       talks:
-          title:GeoPose -1
-          speaker: Christine Perey
-          title: GeoPose -2
-          speaker: Jan-Erik Vinje
-       type: panel
-       details:
-          title: Augmented reality
-       type: breakout
-       details: 
-          title: Maps of Objects: GeoPose for Web maps
-
+      - title: "Advanced web graphics for mapping"
+        type: plenary
+        details:
+          - Talks:
+            - GeoPose -1
+              <span>Christine Perey</span>
+            - GeoPose -2
+              <span>Jan-Erik Vinje</span>
+      - title: Augmented reality
+        type: panel
+      - title: "Maps of Objects: GeoPose for Web maps"
+        type: breakout
   - title: "30 September"
     agenda:
-       - title: ""
-       type: panel
-       details:
-          title: "Stakeholders: Commercial wayfinding services & the web"
-       type: panel
-       details:
-          title: "Stakeholders: Open source for mapping & browsers"
-       type: plenary
-       details:
-       goals:
-       talks:
-          title: "Accessibility presentation from RQTF/APA "
-          speaker: Nicolò Carpignoli
-       type: breakout
-       details:
-          title: "Projections and Vector Symbology"
-
+      - title: "Stakeholders: Commercial wayfinding services & the web"
+        type: panel
+      - title: "Stakeholders: Open source for mapping & browsers"
+        type: panel
+      - title: "Stakeholders: Open source for mapping & browsers"
+        type: plenary
+        details:
+          - Talks:
+            - Accessibility presentation from RQTF/APA
+              <span>Nicolò Carpignoli</span>
+      - title: "Projections and Vector Symbology"
+        type: breakout
   - title: "1 October"
     agenda:
-       - title: "Conclusion / Next Steps"
-       type:
-       details:
-       goals:
-       talks:
-          title: To Be Confirmed
-          speaker: 
-          title: Conclusions and take aways
-          speaker: Peter Rushforth
+      - title: "Conclusion / Next Steps"
+        type:
+        goals:
+        details:
+          - Talks:
+            - Conclusions and take aways
+              <span>Peter Rushforth</span>
+            - "To be confirmed"
 
 
-	  
 # Each agenda item should contain
 # time, as a string describing the range
 # title, as non-interactive HTML (optional for breaks)

--- a/agenda.html
+++ b/agenda.html
@@ -6,27 +6,37 @@ description: >-
   the W3C/OGC Joint Workshop Series on Maps for the Web, September & October 2020.
 layout: default
 schedule:
-  - title: "21 September"
+  - title: "Week 1, Day 1"
+    start: 2020-09-21T04:00Z
     agenda:
-      - title: "State of Web Map widgets today"
-        type: plenary
+      - title: "Introduction"
+        type: presentations
+        duration: "30 minutes"
+        details:
+          - Welcome:
+            - The workshop program committee
+          - Why maps for the web:
+            - Peter Rushforth
+      - title: "State of Web map widgets today"
+        type: presentations
+        duration: "1 hour"
         goals:
         details:
           - Talks:
-            - Introduction/Welcome, Why maps for the web
-              <span>Peter Rushforth</span>
-            - User Cases
+            - Use Cases
               <span>Amelia Bellamy-Royds</span>
             - User Research on Maps in HTML
               <span>Terence Eden</span>
             - Geomoose
               <span>Dan Little</span>
-      - title: Maps in HTML
-        type: panel
-  - title: "22 September"
+#      - title: Maps in HTML
+#        type: panel
+  - title: "Week 1, Day 2"
+    start: 2020-09-22T12:00Z
     agenda:
       - title: "State of map data & server standards today"
-        type: plenary
+        type: presentations
+        duration: "1 hour"
         goals:
         details:
           - Talks:
@@ -40,10 +50,13 @@ schedule:
               <span>Jonathan Moules</span>
       - title: "Government geospatial data providers & the web"
         type: panel
-  - title: "23 September"
+        duration: "45 minutes"
+  - title: "Week 1, Day 3"
+    start: 2020-09-23T16:00Z
     agenda:
       - title: "Native map viewer for the Web platform"
-        type: plenary
+        type: presentations
+        duration: "1 hour"
         details:
           - Talks:
             - Extending the web
@@ -54,27 +67,32 @@ schedule:
               <span>Simon Pieters</span>
             - SVGMap and Distributed Web Maps
               <span>Satoru Takagi</span>
-      - title: "The &lt;map&gt; and &lt;layer&gt; speculative polyfill (MapML)"
-        type: breakout
       - title: "Web Maps Use Cases and Challenges"
         type: panel
-  - title: "24 September"
+        duration: "30 minutes"
+      - title: "The &lt;map&gt; and &lt;layer&gt; speculative polyfill (MapML)"
+        type: breakout
+  - title: "Week 1, Day 4"
+    start: 2020-09-24T22:00Z
     agenda:
       - title: "Internationalized Web maps"
-        type: plenary
+        type: presentations
+        duration: "20 minutes"
         goals:
         details:
           - Talks:
             - Multilingual text rendering
               <span>Brandon Liu</span>
       - title: "Privacy and Security of web maps"
-        type: plenary
+        type: presentations
+        duration: "20 minutes"
         details:
           - Talks:
             - Fuzzy geolocation
               <span>Thijs Brentjens</span>
       - title: "Creating accessible Web map widgets"
-        type: plenary
+        type: presentations
+        duration: "30 minutes"
         details:
           - Talks:
             - UI patterns in existing web map widgets
@@ -83,12 +101,15 @@ schedule:
               <span>Brandon Biggs</span>
       - title: Creating accessible Web map widgets
         type: panel
+        duration: "30 minutes"
       - title: Building Cross-Sensory Maps Using Audiom
         type: breakout
-  - title: "28 September"
+  - title: "Week 2, Day 1"
+    start: 2020-09-28T04:00Z
     agenda:
       - title: "Web Maps for Real-World Accessibility"
-        type: plenary
+        type: presentations
+        duration: "30 minutes"
         details:
           - Talks:
             - Physical accessibility data in maps
@@ -97,26 +118,26 @@ schedule:
               <span>Claudia Loitsch & Julian Striegl</span>
       - title: "Web Maps for Real-World Accessibility"
         type: panel
+        duration: "30 minutes"
       - title: "Building better map data services/formats for web use"
-        type: plenary
+        type: presentations
+        duration: "45 minutes"
         details:
           - Talks:
             - Advanced Analytics Software Project for Geospatial Data
               <span>Nicolas Rafael Palomino</span>
             - Map Compositions format
               <span>Karel Charvat</span>
+              - Embedding rendering & behavior configuration in map data
+                <span>Danielle Dupuy</span>
       - title: Map Whiteboard and format
         type: breakout
-      - title: "MISSING TITLE"
-        type: plenary
-        details:
-          - Talks:
-            - Embedding rendering & behavior configuration in map data
-              <span>Danielle Dupuy</span>
-  - title: "29 September"
+  - title: "Week 2, Day 2"
+    start: 2020-09-29T12:00Z
     agenda:
       - title: "Advanced web graphics for mapping"
-        type: plenary
+        type: presentations
+        duration: "30 minutes"
         details:
           - Talks:
             - GeoPose -1
@@ -125,24 +146,30 @@ schedule:
               <span>Jan-Erik Vinje</span>
       - title: Augmented reality
         type: panel
+        duration: "30 minutes"
       - title: "Maps of Objects: GeoPose for Web maps"
         type: breakout
-  - title: "30 September"
+  - title: "Week 2, Day 3"
+    start: 2020-09-30T16:00Z
     agenda:
-      - title: "Stakeholders: Commercial wayfinding services & the web"
-        type: panel
-      - title: "Stakeholders: Open source for mapping & browsers"
-        type: panel
-      - title: "Stakeholders: Open source for mapping & browsers"
-        type: plenary
+      - title: "Creating accessible Web map widgets (reprise)"
+        type: presentations
+        duration: "20 minutes"
         details:
           - Talks:
             - Accessibility presentation from RQTF/APA
               <span>Nicolò Carpignoli</span>
+      - title: "Stakeholders: Commercial wayfinding services & the web"
+        type: panel
+        duration: "1 hour"
       - title: "Projections and Vector Symbology"
         type: breakout
-  - title: "1 October"
+  - title: "Week 2, Day 4"
+    start: 2020-10-01T22:00Z
     agenda:
+      - title: "Stakeholders: Open source for mapping & browsers"
+        type: panel
+        duration: "1 hour"
       - title: "Conclusion / Next Steps"
         type:
         goals:
@@ -156,7 +183,7 @@ schedule:
 # Each agenda item should contain
 # time, as a string describing the range
 # title, as non-interactive HTML (optional for breaks)
-# type, one of plenary, breakout, or hack
+# type, one of presentations, breakout, or hack
 # open, (optional) boolean indicating whether the details element will be open by default
 # details (optional), a list of headings
 #   each of which is mapped to a list of (one or more) bullet points, as HTML
@@ -215,23 +242,25 @@ schedule:
 </p>
 -->
 
-<article>
+<article class="agenda">
 <h2 id="schedule">Schedule</h2>
 {% for day in page.schedule %}
-  <h3 id="day-{{ forloop.index }}">{{ day.title }}</h3>
+  <h3 id="day-{{ forloop.index }}">{{ day.title }}:
+    <time class="schedule-time" datetime="{{ day.start }}">{{ day.start | date: "%Y-%m-%d %H:%M" }}UTC</time></h3>
   <ol class="schedule">
     {% for item in day.agenda %}
-      <li class="{% unless item.details %}no-details{% endunless %}{% if item.type == 'break' %} break{% endif %}">
-        <details {% if item.open %}open{% endif %}>
+      <li class="schedule-item">
+        <details open>
           <summary>
-            <span class="desc">
-              <span class="time">{{ item.time | replace: 'AM', ' <span>AM</span>' | replace: 'PM', ' <span>PM</span>' }}</span>
-              <span class="title">{{ item.title }}</span>
-              <span class="type type-{{ item.type }}">{{ item.type }}</span>
+            <span class="summary-wrapper">
+              <span class="schedule-item-title">{{ item.title }}</span>
+            <span class="schedule-item-type type-{{ item.type }}">
+              <span class="type">{{ item.type }}</span>
+              <span class="duration">{{ item.duration }}</span>
             </span>
           </summary>
           {% if item.details %}
-            <dl>
+            <dl class="schedule-item-details">
               {% for detail in item.details %}
                 {% for detail_item in detail %}
                   <dt>{{ detail_item[0] }}</dt>
@@ -276,6 +305,37 @@ schedule:
   please see the <a href="{{ relBase }}/call-for-participation">call for participation</a>.
 </p>
 {% endfor %}
+<script>;(function(){
+  let timeElements = document.querySelectorAll(".schedule-time");
+  let date = Intl.DateTimeFormat ?
+    (new Intl.DateTimeFormat("en",
+      {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        weekday: "long"
+      } )) :
+    {format: (function(date) {return date.toDateString() })};
+  let time = Intl.DateTimeFormat ?
+    (new Intl.DateTimeFormat("en",
+      {
+        hour: "numeric",
+        minute: "numeric",
+        timeZoneName: "short"
+      } )) :
+    {format: (function(date) {return date.toTimeString() })};
+
+  for (let i=0; i<timeElements.length; i++) {
+    let timeElement = timeElements[i];
+    let ts = new Date(timeElement.dateTime || timeElement.getAttribute("datetime"));
+    let oldText = timeElement.innerHTML;
+    timeElement.innerHTML = 
+      '<span class="date">' + date.format(ts) + '</span>' +
+      '<span class="time"> @ ' + time.format(ts) + '</span>' +
+      '<span class="utc">(' + oldText + ')</span>';
+  }
+})();
+</script>
 </article>
 
 <h2 id="tips">
@@ -292,24 +352,34 @@ schedule:
   Session Formats
 </h3>
 <dl class="format">
-  <dt class="type type-plenary" id="plenary">
-    plenary
+  <dt class="schedule-item-type type-presentations" id="presentations">
+    presentations
   </dt>
   <dd>
     <p>
-      Plenary sessions introduce topics for discussion
-      which are expected to be relevant to all participants.
+      Presentations are grouped by theme,
+      to introduce topics for discussion.
+      Talks are short (&lt;15 minutes each)
+      and focused on introducing specific work or proposals.
+    </p>
+    <p>
+      If time is available during the live video conference,
+      some questions and discussion may follow the talk.
+      Further questions and comments are encouraged in the online discussion.
+    </p>
+  </dd>
+  <dt class="schedule-item-type type-panel" id="panel">
+    panel
+  </dt>
+  <dd>
+    <p>
+      Moderated panels provide an opportunity
+      for more free-ranging discussion on a theme.
       Speakers are selected in advance by the program committee;
       an assigned moderator will introduce the speakers and coordinate the discussion.
     </p>
     <p>
-      A typical plenary session would be 30-60 minutes
-      and include short talks (&lt;15 minutes),
-      <a href="https://en.wikipedia.org/wiki/Lightning_talk">lightning talks</a>,
-      and/or panel Q&A discussion.
-    </p>
-    <p>
-      The structured video sessions are only the start:
+      The panel discussions are only the start:
       the topics they introduce will be the start of open discussion online,
       where all workshop participants are encouraged
       to exchange ideas, assess priorities,
@@ -318,10 +388,10 @@ schedule:
       and identifying areas of consensus for the final workshop report.
     </p>
   </dd>
-  <dt class="type type-breakout" id="breakout">
+  <dt class="schedule-item-type type-breakout" id="breakout">
     breakout
   </dt>
-  <dt class="type type-hack" id="hack">
+  <dt class="schedule-item-type type-hack" id="hack">
     hack
   </dt>
   <dd>

--- a/agenda.html
+++ b/agenda.html
@@ -50,7 +50,7 @@ schedule:
               <span>Jonathan Moules</span>
       - title: "Government geospatial data providers & the web"
         type: panel
-        duration: "45 minutes"
+        duration: "1 hour"
   - title: "Week 1, Day 3"
     start: 2020-09-23T16:00Z
     agenda:
@@ -67,7 +67,17 @@ schedule:
               <span>Simon Pieters</span>
             - SVGMap and Distributed Web Maps
               <span>Satoru Takagi</span>
-      - title: "Web Maps Use Cases and Challenges"
+      - title: "Internationalized Web maps"
+        type: presentations
+        duration: "30 minutes"
+        goals:
+        details:
+          - Talks:
+            - Multilingual text rendering
+              <span>Brandon Liu</span>
+            - Map Projections and Vector Symbology
+              <span>Gethin Rees</span>
+      - title: "Worldwide Web Maps: Challenges in the global context"
         type: panel
         duration: "30 minutes"
       - title: "The &lt;map&gt; and &lt;layer&gt; speculative polyfill (MapML)"
@@ -75,14 +85,6 @@ schedule:
   - title: "Week 1, Day 4"
     start: 2020-09-24T22:00Z
     agenda:
-      - title: "Internationalized Web maps"
-        type: presentations
-        duration: "20 minutes"
-        goals:
-        details:
-          - Talks:
-            - Multilingual text rendering
-              <span>Brandon Liu</span>
       - title: "Privacy and Security of web maps"
         type: presentations
         duration: "20 minutes"
@@ -99,6 +101,8 @@ schedule:
               <span>Nic Chan</span>
             - Audio maps
               <span>Brandon Biggs</span>
+            - Introduction from the Research Questions Accessibility Task Force (RQTF) of the Accessible Platform Architecture working group
+              <span>Nicolò Carpignoli</span>
       - title: Creating accessible Web map widgets
         type: panel
         duration: "30 minutes"
@@ -135,16 +139,15 @@ schedule:
   - title: "Week 2, Day 2"
     start: 2020-09-29T12:00Z
     agenda:
-      - title: "Advanced web graphics for mapping"
+      - title: "Advances in 3D Map Display"
         type: presentations
         duration: "30 minutes"
         details:
           - Talks:
-            - GeoPose -1
-              <span>Christine Perey</span>
-            - GeoPose -2
-              <span>Jan-Erik Vinje</span>
-      - title: Augmented reality
+            - "GeoPose: From point-of-interest to maps-of-objects
+              <span>Jan-Erik Vinje</span>"
+            - "How GeoPose aligns with use cases and requirements for Web maps <span>Christine Perey</span>"
+      - title: Maps and augmented reality
         type: panel
         duration: "30 minutes"
       - title: "Maps of Objects: GeoPose for Web maps"
@@ -152,7 +155,7 @@ schedule:
   - title: "Week 2, Day 3"
     start: 2020-09-30T16:00Z
     agenda:
-      - title: "Advanced web graphics for mapping (reprise)"
+      - title: "Advanced web graphics for mapping"
         type: presentations
         duration: "60 minutes"
         details:
@@ -165,37 +168,23 @@ schedule:
               <span>Andreas Hocevar</span>
             - Dynamic and Observational Spatial Data
               <span>Hylke van der Schaaf, Thomas Usländer, Katharina Schleidt</span>
-  - title: "Week 2, Day 4"
-    start: 2020-10-01T22:00Z
-    agenda:
-      - title: "Creating accessible Web map widgets"
-        type: presentations
-        duration: "15 minutes"
-        details:
-          - Talks:
-            - Accessibility presentation from RQTF/APA
-              <span>Nicolò Carpignoli</span>
-      - title: "Web map internationalization"
-        type: breakout
-        duration: "15 minutes"
-        details:
-          - Talks:
-            - Map Projections and Vector Symbology
-              <span>Gethin Rees</span>
-      - title: "Stakeholders: Open source for mapping & browsers"
-        type: panel
-        duration: "1 hour"
       - title: "Stakeholders: Commercial wayfinding services & the web"
         type: panel
         duration: "1 hour"
+  - title: "Week 2, Day 4"
+    start: 2020-10-01T22:00Z
+    agenda:
+      - title: "Stakeholders: Open source for mapping & browsers"
+        type: panel
+        duration: "1 hour"
       - title: "Conclusion / Next Steps"
-        type:
+        type: discussion
+        duration: "30 minutes"
         goals:
         details:
           - Talks:
             - Conclusions and take aways
-              <span>Peter Rushforth</span>
-            - "To be confirmed"
+              <span>The workshop program committee</span>
 
 
 # Each agenda item should contain

--- a/agenda.html
+++ b/agenda.html
@@ -6,6 +6,186 @@ description: >-
   the W3C/OGC Joint Workshop Series on Maps for the Web, September & October 2020.
 layout: default
 schedule:
+
+  - title: "21 September"
+    agenda:
+       - title: "State of Web Map widgets today"
+       type: plenary
+       goals:       
+       details:
+       talks:
+          title: "Introduction/Welcome, Why maps for the web"
+          speaker: Peter Rushforth
+	  title: "User Cases"
+	  speaker:Amelia Bellamy-Royds
+	  title: "User Research on Maps in HTML"
+	  speaker: Terence Eden
+	  title: Geomoose
+	  speaker: Dan Little
+
+       type: panel
+       details:
+          title: Maps in HTML
+	  
+  - title: "22 September"
+    agenda:
+       - title: "State of map data & server standards today"
+       type: plenary
+       details:
+       goals:
+       talks:
+          title: OGC APIs for web use
+          speaker: Gobe Hobona
+	  title: pygeoapi
+	  speaker: Tom Angelos Francesco
+	  title: Connection of the MapML initiative with OGC standards such as the new OGC API Tiles candidate or the old WMS.
+	  speaker: Joan Masó
+	  title: Limitations to use of OGC services
+	  speaker: Jonathan Moules
+       type: panel
+       details:
+          title: "Government geospatial data providers & the web"
+
+  - title: "23 September"
+    agenda:
+       - title: "Native map viewer for the Web platform"
+       type:
+       details:
+       goals:
+       talks:
+          title: "Extending the web"
+          speaker: Brian Kardell
+          title: The MapML proposal
+          speaker: Peter Rushforth
+          title: "Bocoup's Review of the MapML Proposal"
+          speaker: Simon Pieters
+          title: SVGMap and Distributed Web Maps 
+          speaker: Satoru Takagi
+          title: 
+          speaker: 
+       type: breakout
+       details:
+          title: "The <map> and <layer> speculative polyfill (MapML)"	  
+       type: panel
+       details:
+          title: "Web Maps Use Cases and Challenges" 
+
+  - title: "24 September"
+    agenda:
+       - title: "Internationalized Web maps"
+       type: plenary
+       details:
+       goals:
+       talks:
+          title: Multilingual text rendering
+          speaker: Brandon Liu
+       - title: "Privacy and Security of web maps"
+       type: plenary
+       details:
+       goals:
+       talks:
+          title: Fuzzy geolocation 
+          speaker: Thijs Brentjens
+       - title: "Creating accessible Web map widgets"
+       type: plenary
+       details:
+       goals:
+       talks:
+          title: UI patterns in existing web map widgets
+          speaker: Nic Chan
+          title: Audio maps
+          speaker: Brandon Biggs
+       type: panel
+       details:
+          title: Creating accessible Web map widgets
+       type: breakout
+       details:
+          title: Building Cross-Sensory Maps Using Audiom,,
+
+    - title: "28 September"
+    agenda:
+       - title: "Web Maps for Real-World Accessibility"
+       type: plenary
+       details:
+       goals:
+       talks:
+          title: Physical accessibility data in maps 
+          speaker: Sebastian Zappe
+          title: Indoor maps
+          speaker: "Claudia Loitsch & Julian Striegl"
+      type: panel
+       details:
+          title: "Web Maps for Real-World Accessibility"	  
+       - title: "Building better map data services/formats for web use"
+       type: plenary
+       details:
+       goals:
+       talks:
+          title: Advanced Analytics Software Project for Geospatial Data
+          speaker: Nicolas Rafael Palomino
+          title: Map Compositions format
+          speaker: Karel Charvat
+       type: breakout
+       details:
+          title: Map Whiteboard and format
+       type: plenary
+       details:
+       goals:
+       talks:
+          title: Embedding rendering & behavior configuration in map data
+          speaker: Danielle Dupuy
+	  
+  - title: "29 September"
+    agenda:
+       - title: "Advanced web graphics for mapping"
+       type:
+       details:
+       goals:
+       talks:
+          title:GeoPose -1
+          speaker: Christine Perey
+          title: GeoPose -2
+          speaker: Jan-Erik Vinje
+       type: panel
+       details:
+          title: Augmented reality
+       type: breakout
+       details: 
+          title: Maps of Objects: GeoPose for Web maps
+
+  - title: "30 September"
+    agenda:
+       - title: ""
+       type: panel
+       details:
+          title: "Stakeholders: Commercial wayfinding services & the web"
+       type: panel
+       details:
+          title: "Stakeholders: Open source for mapping & browsers"
+       type: plenary
+       details:
+       goals:
+       talks:
+          title: "Accessibility presentation from RQTF/APA "
+          speaker: Nicolò Carpignoli
+       type: breakout
+       details:
+          title: "Projections and Vector Symbology"
+
+  - title: "1 October"
+    agenda:
+       - title: "Conclusion / Next Steps"
+       type:
+       details:
+       goals:
+       talks:
+          title: To Be Confirmed
+          speaker: 
+          title: Conclusions and take aways
+          speaker: Peter Rushforth
+
+
+	  
 # Each agenda item should contain
 # time, as a string describing the range
 # title, as non-interactive HTML (optional for breaks)

--- a/agenda.html
+++ b/agenda.html
@@ -152,22 +152,40 @@ schedule:
   - title: "Week 2, Day 3"
     start: 2020-09-30T16:00Z
     agenda:
-      - title: "Creating accessible Web map widgets (reprise)"
+      - title: "Advanced web graphics for mapping (reprise)"
         type: presentations
-        duration: "20 minutes"
+        duration: "60 minutes"
+        details:
+          - Talks:
+            - Map adventures in weird web standards - gyroscopes, texture cubes, and mutants
+              <span>Iván Sánchez Ortega</span>
+            - MapML implementations in MapServer, GDAL and OGR
+              <span>Daniel Morrissette</span>
+            - OffScreenCanvas
+              <span>Andreas Hocevar</span>
+            - Dynamic and Observational Spatial Data
+              <span>Hylke van der Schaaf, Thomas Usländer, Katharina Schleidt</span>
+  - title: "Week 2, Day 4"
+    start: 2020-10-01T22:00Z
+    agenda:
+      - title: "Creating accessible Web map widgets"
+        type: presentations
+        duration: "15 minutes"
         details:
           - Talks:
             - Accessibility presentation from RQTF/APA
               <span>Nicolò Carpignoli</span>
-      - title: "Stakeholders: Commercial wayfinding services & the web"
+      - title: "Web map internationalization"
+        type: breakout
+        duration: "15 minutes"
+        details:
+          - Talks:
+            - Map Projections and Vector Symbology
+              <span>Gethin Rees</span>
+      - title: "Stakeholders: Open source for mapping & browsers"
         type: panel
         duration: "1 hour"
-      - title: "Projections and Vector Symbology"
-        type: breakout
-  - title: "Week 2, Day 4"
-    start: 2020-10-01T22:00Z
-    agenda:
-      - title: "Stakeholders: Open source for mapping & browsers"
+      - title: "Stakeholders: Commercial wayfinding services & the web"
         type: panel
         duration: "1 hour"
       - title: "Conclusion / Next Steps"

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -225,13 +225,9 @@ a.ref {
   width: 100%;
 }
 
-.box,
-.type {
+.box {
   box-shadow: .3em .3em 0 rgba(0,0,0,.1);
   border: 1px solid #ccc;
-}
-
-.box {
   color: #666;
   font-size: 0.9rem;
   margin-left: 3rem;
@@ -554,126 +550,78 @@ a.footnote-ref:after {
   padding: .1em .5em;
 }
 
-.schedule {
-  list-style: none;
+.agenda h3 {
+  background: #005a9c;
+  color: white;
+  box-shadow: 0 0 0 0.2rem #005a9c,
+    0.1rem 0.1rem 0 0.2rem rgba(0,0,0,0.4);
+  border-radius: 0.2rem;
 }
 
-.schedule li,
-summary .desc {
-  display: flex;
+.schedule-time {
+  display: block;
+  font-weight: normal;
+}
+.schedule-time .utc {
+  display: block;
+  font-size: 1rem;
+  opacity: 0.8;
+}
+
+.schedule {
+  list-style: none;
 }
 
 .schedule li + li {
   margin-top: .5rem;
 }
 
-summary .time {
-  background-color: #005c9c;
-  border-radius: 5px 0 0 5px;
-  color: #fff;
+.schedule-item summary {
+  list-style-position: outside;
+  position: relative;
+}
+.schedule-item summary::-webkit-details-marker {
+  position: absolute;
+  left: -1rem;
+}
+
+.schedule-item .summary-wrapper {
+  display: flex;
+  justify-content: space-between;
+}
+
+.schedule-item-title {
+  padding-left: 0.2em;
+}
+
+.schedule-item-type {
+  background-color: #ddd;
   display: block;
   font-weight: bold;
-  margin-bottom: 5px;
+  font-size: 80%;
   min-width: 8em;
-  vertical-align: top;
+  padding: 0.2em 0.5em;
   white-space: nowrap;
 }
-
-summary .time,
-.title,
-.type {
-  padding: 3px 6px;
-}
-
-.break summary .time {
-  background-color: #666;
-  color: #fff;
-}
-
-.break .title {
-  color: gray;
-  font-style: italic;
-}
-
-summary .time span { font-size: 67%; }
-
-.type {
-  clear: right;
-  display: inline-block;
-  font-size: 67%;
-  font-weight: normal;
-  height: 100%;
-  margin: 0 13px 0 0;
-  order: -1;
-  min-width: 6.5em;
-}
-
-.type:empty {
-  border-color: transparent;
-  box-shadow: none;
-}
-
-dt.type {
-  font-size: 100%;
-  margin: 0;
+.schedule-item-type > * {
+  display: block;
   text-align: center;
 }
 
-.type-plenary, .type-keynote {
+.schedule-item-type.type-plenary,
+.schedule-item-type.type-presentations,
+.schedule-item-type.type-keynote {
   background-color: #b9d3ee;
 }
 
-.type-breakout, .type-hack {
+.schedule-item-type.type-panel {
+  background-color: #d6f6b6;
+}
+
+.schedule-item-type.type-breakout,
+.schedule-item-type.type-hack,
+.schedule-item-type.type-demo {
   background-color: #ffe7ba;
-}
-
-span.title {
-  display: block;
-  flex: 1;
-  margin-left: 5px;
-  order: 1;
-}
-
-.schedule summary::-webkit-details-marker {
-  display: none;
-}
-
-.schedule summary::-moz-list-bullet {
-  list-style-type: none;
-}
-
-.schedule summary {
-  list-style-type: none;
-}
-
-.schedule li:not(.no-details) details summary .desc {
-  cursor: pointer;
-}
-
-.schedule details summary .desc:before {
-  color: #999;
-  content: "▶";
-  display: inline-block;
-  height: 1.1em;
-  margin-right: 0.5em;
-  order: -2;
-  width: 1.1em;
-}
-
-.schedule details[open] summary .desc:before {
-  color: #666;
-  transform: rotate(90deg);
-  position: relative;
-  left: -2px;
-  top: 2px;
-}
-
-.schedule .no-details details .desc:before {
-  content: "";
-}
-
-.schedule details {
-  width: 100%;
 }
 
 .schedule summary:focus-visible {
@@ -681,45 +629,35 @@ span.title {
   outline-offset: 2px;
 }
 
-.schedule details dl {
-  box-shadow: .3em .3em 0 rgba(0,0,0,.1);
+.schedule-item-details,
+.schedule-item .summary-wrapper {
+  box-shadow: 0.3rem 0.3rem 0 rgba(0,0,0,.1);
   border: 1px solid #ccc;
+}
+.schedule-item-details {
   margin: 9px 0 5px 27px;
   padding: 1rem;
   position: relative;
 }
 
-/* from http://nicolasgallagher.com/pure-css-speech-bubbles/demo/ */
-.schedule details dl::after {
-  border-color: #005c9c transparent;
-  border-style: solid;
-  border-width: 15px 15px 0;
-  content: "";
-  display: block;
-  left: 8em;
-  position: absolute;
-  top: -16px;
-  width: 0;
-}
-
-.schedule details dt {
+.schedule-item-details dt {
   margin: 0;
 }
 
-.schedule details dd {
+.schedule-item-details dd {
   margin: 0 0 0 1rem;
   border: none;
   padding: 0;
 }
 
-.schedule details dd span {
+.schedule-item-details dd span {
   font-size: 75%;
   color: #888;
   display: block;
   margin-bottom: .25em;
 }
 
-.schedule details dd + dt {
+.schedule-item-details dd + dt {
   margin-top: 1rem;
 }
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -708,6 +708,8 @@ span.title {
 
 .schedule details dd {
   margin: 0 0 0 1rem;
+  border: none;
+  padding: 0;
 }
 
 .schedule details dd span {


### PR DESCRIPTION
Apologies for the duplicate PR, I do not have write access to the repository. I have formatted the draft agenda in #65. (do not worry, I used regex so it didn't take that long!) 

I have attached a screenshot of the current agenda with all the collapsible elements uncollapsed for those who are unable to run the build locally. 

## Questions
- I believe we are missing a plenary title on September 28, what should this be called
- Will we add timestamps eventually? If not, should I revise the styling to remove the timestamp space?


<details>
<summary>Screenshot of the agenda</summary>
<img src="https://user-images.githubusercontent.com/12852862/90311047-c3cf0900-df29-11ea-9230-4a65fcab09a4.png">
</details>

@AmeliaBR @prushforth @tguild 
