### PR TITLE
Agenda tweaks

### DIFF
--- a/agenda.html
+++ b/agenda.html
@@ -15,8 +15,9 @@ schedule:
         details:
           - Welcome:
             - The workshop program committee
-          - Why maps for the web:
-            - Peter Rushforth
+          - Talks:
+              - Why maps for the web
+                <span>Peter Rushforth</span>
       - title: "State of Web map widgets today"
         type: presentations
         duration: "1 hour"
@@ -25,8 +26,6 @@ schedule:
           - Talks:
             - Use Cases
               <span>Amelia Bellamy-Royds</span>
-            - User Research on Maps in HTML
-              <span>Terence Eden</span>
             - Geomoose
               <span>Dan Little</span>
 #      - title: Maps in HTML
@@ -67,7 +66,7 @@ schedule:
               <span>Simon Pieters</span>
             - SVGMap and Distributed Web Maps
               <span>Satoru Takagi</span>
-      - title: "Internationalized Web maps"
+      - title: "Internationalization and Security"
         type: presentations
         duration: "30 minutes"
         goals:
@@ -75,23 +74,18 @@ schedule:
           - Talks:
             - Multilingual text rendering
               <span>Brandon Liu</span>
-            - Map Projections and Vector Symbology
-              <span>Gethin Rees</span>
+            - Fuzzy geolocation
+              <span>Thijs Brentjens</span>
       - title: "Worldwide Web Maps: Challenges in the global context"
         type: panel
         duration: "30 minutes"
-      - title: "The &lt;map&gt; and &lt;layer&gt; speculative polyfill (MapML)"
+      - title: "Map Projections and Vector Symbology"
         type: breakout
+        details:
+          - Facilitator: Gethin Rees
   - title: "Week 1, Day 4"
     start: 2020-09-24T22:00Z
     agenda:
-      - title: "Privacy and Security of web maps"
-        type: presentations
-        duration: "20 minutes"
-        details:
-          - Talks:
-            - Fuzzy geolocation
-              <span>Thijs Brentjens</span>
       - title: "Creating accessible Web map widgets"
         type: presentations
         duration: "30 minutes"
@@ -101,13 +95,14 @@ schedule:
               <span>Nic Chan</span>
             - Audio maps
               <span>Brandon Biggs</span>
-            - Introduction from the Research Questions Accessibility Task Force (RQTF) of the Accessible Platform Architecture working group
-              <span>Nicolò Carpignoli</span>
-      - title: Creating accessible Web map widgets
-        type: panel
-        duration: "30 minutes"
       - title: Building Cross-Sensory Maps Using Audiom
         type: breakout
+        details:
+          - Facilitator: Brandon Biggs
+      - title: "The &lt;map&gt; and &lt;layer&gt; speculative polyfill (MapML)"
+        type: breakout
+        details:
+          - Facilitator: Peter Rushforth
   - title: "Week 2, Day 1"
     start: 2020-09-28T04:00Z
     agenda:
@@ -120,7 +115,7 @@ schedule:
               <span>Sebastian Zappe</span>
             - Indoor maps
               <span>Claudia Loitsch & Julian Striegl</span>
-      - title: "Web Maps for Real-World Accessibility"
+      - title: "Web Maps for Cognitive Accessibility"
         type: panel
         duration: "30 minutes"
       - title: "Building better map data services/formats for web use"
@@ -130,15 +125,21 @@ schedule:
           - Talks:
             - Advanced Analytics Software Project for Geospatial Data
               <span>Nicolas Rafael Palomino</span>
-            - Map Compositions format
-              <span>Karel Charvat</span>
-              - Embedding rendering & behavior configuration in map data
+            - Embedding rendering & behavior configuration in map data
                 <span>Danielle Dupuy</span>
-      - title: Map Whiteboard and format
-        type: breakout
   - title: "Week 2, Day 2"
     start: 2020-09-29T12:00Z
     agenda:
+      - title: Creating accessible Web map widgets
+        type: presentations
+        duration: "20 minutes"
+        details:
+          - Talks:
+            - Introduction from the Research Questions Accessibility Task Force (RQTF) of the Accessible Platform Architecture working group
+              <span>Nicolò Carpignoli</span>
+      - title: Creating accessible Web map widgets
+        type: panel
+        duration: "30 minutes"
       - title: "Advances in 3D Map Display"
         type: presentations
         duration: "30 minutes"
@@ -162,18 +163,32 @@ schedule:
           - Talks:
             - Map adventures in weird web standards - gyroscopes, texture cubes, and mutants
               <span>Iván Sánchez Ortega</span>
+            - Map Compositions format
+              <span>Karel Charvat</span>
             - MapML implementations in MapServer, GDAL and OGR
               <span>Daniel Morrissette</span>
-            - OffScreenCanvas
+            - OffScreenCanvas for rendering performance
               <span>Andreas Hocevar</span>
             - Dynamic and Observational Spatial Data
               <span>Hylke van der Schaaf, Thomas Usländer, Katharina Schleidt</span>
       - title: "Stakeholders: Commercial mapping services & the web"
         type: panel
         duration: "1 hour"
+      - title: "Map Whiteboard: Collaborative Map-Making"
+        type: breakout
+        details:
+          - Facilitator: Karel Charvat
   - title: "Week 2, Day 4"
     start: 2020-10-01T22:00Z
     agenda:
+      - title: "Web developer priorities"
+        type: presentations
+        duration: "20 minutes"
+        goals:
+        details:
+          - Talks:
+            - User Research on Maps in HTML
+              <span>Terence Eden</span>
       - title: "Stakeholders: Open source for mapping & browsers"
         type: panel
         duration: "1 hour"

--- a/agenda.html
+++ b/agenda.html
@@ -168,7 +168,7 @@ schedule:
               <span>Andreas Hocevar</span>
             - Dynamic and Observational Spatial Data
               <span>Hylke van der Schaaf, Thomas Usländer, Katharina Schleidt</span>
-      - title: "Stakeholders: Commercial wayfinding services & the web"
+      - title: "Stakeholders: Commercial mapping services & the web"
         type: panel
         duration: "1 hour"
   - title: "Week 2, Day 4"


### PR DESCRIPTION
Based on conflicts / time-zone complaints from presenters, along with some other clean-up.

Re issue #68

Changes made:
- Terence Eden presentation moved from W1D1 to W2D4
- Thijs Brentjens moved from W1D4 to W1D3
  (theme merged with internationalization)
- Gethin Rees on vector symbology changed from talk to breakout on W1D3
- Peter R's breakout moved from W1D3 to W1D4
- Accessible Widgets panel & Nicolò Carpignoli's presentation
  moved from W1D4 to W2D2
- Karel Charvat's presentation & breakout moved from W2D1 to W2D3

Also:
Facilitator information added for breakouts

Changes name of commercial stakeholder panel Closes #77