### PR TITLE
Reformat agenda page for Video & discussion links

### DIFF
--- a/_data/agenda.yml
+++ b/_data/agenda.yml
@@ -1,5 +1,6 @@
 - title: "Week 1, Day 1"
   start: 2020-09-21T04:00Z
+  video: https://www.youtube.com/watch?v=Ji3HF35Hpso&list=PLNhYw8KaLq2VuEWzz096iRjtvWel-p2AJ&index=1
   agenda:
     - title: "Introduction"
       type: presentations
@@ -10,6 +11,7 @@
         - Talks:
             - title: Why maps for the web
               author: Peter Rushforth
+              discourse: https://discourse.wicg.io/t/why-maps-for-html/4797/2
               link: https://www.w3.org/2020/maps/supporting-material-uploads/presentations/Why%20Maps%20for%20HTML%20-%20Peter%20Rushforth.pptx
     - title: "State of Web map widgets today"
       type: presentations
@@ -19,15 +21,16 @@
         - Talks:
             - title: Use Cases
               author: Amelia Bellamy-Royds
+              discourse: https://discourse.wicg.io/t/use-cases-and-requirements-for-web-maps/4796/3
+              link: https://maps4html.org/HTML-Map-Element-UseCases-Requirements/
+              linktype: draft report
             - title: Geomoose
               author: Dan Little
+              discourse: https://discourse.wicg.io/t/the-geomoose-web-mapping-framework/4799
               link: https://www.w3.org/2020/maps/supporting-material-uploads/presentations/geomoose-dan-little-slides.pdf
-    - title: "Video for day 1"
-      type: recording
-      duration: "1 hour 20 minutes"
-      link: https://www.youtube.com/watch?v=Ji3HF35Hpso&list=PLNhYw8KaLq2VuEWzz096iRjtvWel-p2AJ&index=1
 - title: "Week 1, Day 2"
   start: 2020-09-22T12:00Z
+# video: YouTube-URL-for-day-2
   agenda:
     - title: "State of map data & server standards today"
       type: presentations
@@ -40,9 +43,11 @@
               link: https://www.w3.org/2020/maps/supporting-material-uploads/presentations/Gobe_Hobona.pptx
             - title: pygeoapi
               author: Tom Kralidis, Angelos Tzotsos, Francesco Bartoli
+              discourse: https://discourse.wicg.io/t/pygeoapi-an-ogc-api-to-geospatial-data/4814
               link: https://pygeoapi.io/presentations/default/#/frontpage
             - title: Connection of the MapML initiative with OGC standards such as the new OGC API Tiles candidate or the old WMS
               author: Joan Masó
+              discourse: https://discourse.wicg.io/t/ogc-api-tiles-as-provider-of-tiles-and-mapml-documents/4811
               link: https://www.w3.org/2020/maps/supporting-material-uploads/presentations/Joan_Maso_Connection_Of_The_MapML_Initiative_With_OGC_Standards-V2.pptx
             - title: Limitations to use of OGC services
               author: Jonathan Moules
@@ -77,6 +82,7 @@
               link: https://slides.com/zcorpan/bocoup-review-mapml/
             - title: Quad Tree Composite Tiling and the standardization of tiling; Decentralized Web Mapping
               author: Satoru Takagi
+              discourse: https://discourse.wicg.io/t/vector-tiling-on-svgmap/3135
               link: https://satakagi.github.io/mapsForWebWS2020-docs/
     - title: "Internationalization and Security"
       type: presentations
@@ -158,6 +164,8 @@
             - John Rochford
         - Moderator:
             - Amelia Bellamy-Royds
+        - Background Reading:
+            - '<a href="https://w3c.github.io/coga/issue-papers/wayfinding-indoors.html">COGA Issue Paper on Indoor Navigation / Wayfinding</a>'
     - title: "Building better map data services/formats for web use"
       type: presentations
       duration: "60 minutes"
@@ -300,6 +308,9 @@
 #         - Talks:
 #             - title: Why maps for the web
 #               author: Peter Rushforth
+#               discourse: url-of-discourse-page
+#               link: url-of-slides-or-paper
+#               linktype: link text if not slides
 #     - title: "Stakeholders: Government geospatial data providers & the web"
 #       type: panel
 #       duration: "1 hour"

--- a/agenda.html
+++ b/agenda.html
@@ -71,7 +71,12 @@ layout: default
 </p>
 {% for day in site.data.agenda %}
   <h3 id="day-{{ forloop.index }}">{{ day.title }}:
-    <time class="schedule-time" datetime="{{ day.start }}">{{ day.start | date: "%Y-%m-%d %H:%M" }}UTC</time></h3>
+    {% if day.video %}
+    <a class="schedule-video-link" href="{{ day.video }}"
+      >Watch recording<span class="visually-hidden"> of {{ day.title }} sessions</span></a>
+    {% endif %}
+    <time class="schedule-time{% if day.video %} past-event{% endif %}"
+          datetime="{{ day.start }}">{{ day.start | date: "%Y-%m-%d %H:%M" }}UTC</time></h3>
   <ol class="schedule">
     {% for item in day.agenda %}
       <li class="schedule-item">
@@ -104,9 +109,12 @@ layout: default
                           {{ talk.title }}
                         {% endif %}
                         {% if talk.link %}
-                          <a href="{{ talk.link }}">(slides)</a>
+                          <a class="slides-link" href="{{ talk.link }}">({{ talk.linktype | default: "slides"}})</a>
                         {% endif %}
-                        <span class="author">{% include participant-link.html participant=talk.author %}</span>
+                        <span class="author schedule-talk-info">{% include participant-link.html participant=talk.author %}</span>
+                        {% if talk.discourse %}
+                        <span class="discussion schedule-talk-info"><a href="{{ talk.discourse }}">Join the discussion!</a></span>
+                        {% endif %}
                       </dd>
                     {% endfor %}
                   {% elsif detail_item[0] == 'Panelists' %}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -560,11 +560,24 @@ a.footnote-ref:after {
   border-radius: 0.2rem;
 }
 
+.schedule-video-link {
+  display: inline-block;
+  padding: 0.25em;
+  border-radius: 0.2em;
+  background: white;
+  color: #005a9c;
+}
+.schedule-video-link::before {
+  content: "🎦 ";
+  font-size: 90%;
+  margin-left: -0.1em;
+}
 .schedule-time {
   display: block;
   font-weight: normal;
 }
-.schedule-time .utc {
+.schedule-time.past-event,
+.schedule-time:not(.past-event) .utc {
   display: block;
   font-size: 1rem;
   opacity: 0.8;
@@ -649,16 +662,21 @@ a.footnote-ref:after {
 }
 
 .schedule-item-details dd {
-  margin: 0 0 0 1rem;
-  border: none;
+  margin: 0 0 0.5rem;
+  border-top: none;
   padding: 0;
 }
+.schedule-item-details dd:last-child {
+  margin-bottom: 0;
+}
 
-.schedule-item-details dd .author {
-  font-size: 75%;
-  color: #888;
+.schedule-talk-info {
+  font-size: 90%;
   display: block;
   margin-bottom: .25em;
+}
+.schedule-talk-info::before {
+  content: "→ ";
 }
 
 .schedule-item-details dd + dt {
@@ -792,6 +810,9 @@ button {
 
 main a[href$=".pdf"]::after {
 	content: " (PDF)";
+}
+main a.slides-link[href$=".pdf"]::after {
+	content: none;
 }
 
 .visually-hidden {


### PR DESCRIPTION
cc-ing @prushforth, @tguild, @nchan0154 since you'll need to figure out the updated YAML structure if doing any updates.

Ted, I liked your solution for getting the video link up as another agenda item, but this should be easier! I even left in a YAML comment for where the next link goes:

```yaml
- title: "Week 1, Day 2"
  start: 2020-09-22T12:00Z
# video: YouTube-URL-for-day-2
  agenda:
```

I've added links to the talk discourse pages created so far, remember to keep adding them as we go along.

-----
Commit notes:

We're only posting one video per day, so put it up next to the heading for the day, with extra formatting to call it out.

De-emphasize the session time when a video is available.

Add a discourse link to individual talks.

Support alternatives to “slides” link & suppress the (PDF) on them.

Tweak some styling (of course).

Add the links we have, plus a background-reading link for the COGA panel
(I gave up on making a template for that. Back to HTML in the YAML.)