### PR TITLE
Update base styles for minutes and captions

### DIFF
--- a/supporting-material-uploads/minutes/20200921-captions.html
+++ b/supporting-material-uploads/minutes/20200921-captions.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang='en'>
 <head>
+  <meta charset="utf-8">
   <title>Captions from W3C/OGC Maps for the Web workshop -- 21 Sep 2020</title>
 </head>
 <body>

--- a/supporting-material-uploads/minutes/20200921-captions.html
+++ b/supporting-material-uploads/minutes/20200921-captions.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Captions from W3C/OGC Maps for the Web workshop -- 21 Sep 2020</title>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
 <p>Amelia Bellamy-Royds: Hello everyone who's joined so far.</p>

--- a/supporting-material-uploads/minutes/20200921-min.html
+++ b/supporting-material-uploads/minutes/20200921-min.html
@@ -1,12 +1,13 @@
 <!DOCTYPE html>
 <html lang='en'>
 <head>
-  <title>W3C/OGC Maps for the Web workshop -- 21 Sep 2020</title>
-  <link type="text/css" rel="STYLESHEET" href="https://www.w3.org/StyleSheets/base.css">
-  <link type="text/css" rel="STYLESHEET" href="https://www.w3.org/StyleSheets/public.css">
-  <link type="text/css" rel="STYLESHEET" href="https://www.w3.org/2004/02/minutes-style.css">
-  <meta content="W3C/OGC Maps for the Web workshop" name="Title">  
   <meta charset="utf-8">
+  <title>W3C/OGC Maps for the Web workshop -- 21 Sep 2020</title>
+  <link rel="stylesheet" href="https://www.w3.org/StyleSheets/base.css">
+  <link rel="stylesheet" href="https://www.w3.org/StyleSheets/public.css">
+  <link rel="stylesheet" href="https://www.w3.org/2004/02/minutes-style.css">
+  <link rel="stylesheet" href="style.css">
+  <meta content="W3C/OGC Maps for the Web workshop" name="Title">  
 </head>
 
 <body>

--- a/supporting-material-uploads/minutes/20200922-captions.html
+++ b/supporting-material-uploads/minutes/20200922-captions.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang='en'>
 <head>
+  <meta charset="utf-8">
   <title>Captions from W3C/OGC Maps for the Web workshop -- 22 Sep 2020</title>
 </head>
 <body>

--- a/supporting-material-uploads/minutes/20200922-captions.html
+++ b/supporting-material-uploads/minutes/20200922-captions.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Captions from W3C/OGC Maps for the Web workshop -- 22 Sep 2020</title>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
 <p>Peter Rushforth: Well, welcome everyone to the day two of the maps for the web workshop that joint WPC oh GC map for the web workshop and Peter rush FORTH AND VERY PLEASED TO Peter Rushforth: That if all joined us today.</p>

--- a/supporting-material-uploads/minutes/20200922-min.html
+++ b/supporting-material-uploads/minutes/20200922-min.html
@@ -1,12 +1,13 @@
 <!DOCTYPE html>
 <html lang='en'>
 <head>
-  <title>W3C/OGC Maps for the Web workshop -- 22 Sep 2020</title>
-  <link type="text/css" rel="STYLESHEET" href="https://www.w3.org/StyleSheets/base.css">
-  <link type="text/css" rel="STYLESHEET" href="https://www.w3.org/StyleSheets/public.css">
-  <link type="text/css" rel="STYLESHEET" href="https://www.w3.org/2004/02/minutes-style.css">
-  <meta content="W3C/OGC Maps for the Web workshop" name="Title">  
   <meta charset="utf-8">
+  <title>W3C/OGC Maps for the Web workshop -- 22 Sep 2020</title>
+  <link rel="stylesheet" href="https://www.w3.org/StyleSheets/base.css">
+  <link rel="stylesheet" href="https://www.w3.org/StyleSheets/public.css">
+  <link rel="stylesheet" href="https://www.w3.org/2004/02/minutes-style.css">
+  <link rel="stylesheet" href="style.css">
+  <meta content="W3C/OGC Maps for the Web workshop" name="Title">  
 </head>
 
 <body>

--- a/supporting-material-uploads/minutes/20200923-captions.html
+++ b/supporting-material-uploads/minutes/20200923-captions.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang='en'>
 <head>
+  <meta charset="utf-8">
   <title>Captions from W3C/OGC Maps for the Web workshop -- 23 Sep 2020</title>
 </head>
 <body>

--- a/supporting-material-uploads/minutes/20200923-captions.html
+++ b/supporting-material-uploads/minutes/20200923-captions.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Captions from W3C/OGC Maps for the Web workshop -- 23 Sep 2020</title>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
 <p>Amelia Bellamy-Royds: Okay.</p>

--- a/supporting-material-uploads/minutes/20200923-min.html
+++ b/supporting-material-uploads/minutes/20200923-min.html
@@ -1,12 +1,13 @@
 <!DOCTYPE html>
 <html lang='en'>
 <head>
-  <title>W3C/OGC Maps for the Web workshop -- 23 Sep 2020</title>
-  <link type="text/css" rel="STYLESHEET" href="https://www.w3.org/StyleSheets/base.css">
-  <link type="text/css" rel="STYLESHEET" href="https://www.w3.org/StyleSheets/public.css">
-  <link type="text/css" rel="STYLESHEET" href="https://www.w3.org/2004/02/minutes-style.css">
-  <meta content="W3C/OGC Maps for the Web workshop" name="Title">  
   <meta charset="utf-8">
+  <title>W3C/OGC Maps for the Web workshop -- 23 Sep 2020</title>
+  <link rel="stylesheet" href="https://www.w3.org/StyleSheets/base.css">
+  <link rel="stylesheet" href="https://www.w3.org/StyleSheets/public.css">
+  <link rel="stylesheet" href="https://www.w3.org/2004/02/minutes-style.css">
+  <link rel="stylesheet" href="style.css">
+  <meta content="W3C/OGC Maps for the Web workshop" name="Title">  
 </head>
 
 <body>

--- a/supporting-material-uploads/minutes/20200924-captions.html
+++ b/supporting-material-uploads/minutes/20200924-captions.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Captions from W3C/OGC Maps for the Web workshop -- 24 Sep 2020</title>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
 <p>Peter Rushforth: On day four of the joint W3C/OGC maps for the web workshop and Peter Rushforth: We're going to be starting the the agenda tonight with Peter Rushforth: On the topic of creating accessible web map widgets with two presentations for the first from Nick Chen, who will be presenting first her and Robert lenders work who are Robert and Nick are both members of the master HTML community group and they've done.</p>

--- a/supporting-material-uploads/minutes/20200924-captions.html
+++ b/supporting-material-uploads/minutes/20200924-captions.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang='en'>
 <head>
+  <meta charset="utf-8">
   <title>Captions from W3C/OGC Maps for the Web workshop -- 24 Sep 2020</title>
 </head>
 <body>

--- a/supporting-material-uploads/minutes/20200924-min.html
+++ b/supporting-material-uploads/minutes/20200924-min.html
@@ -1,12 +1,13 @@
 <!DOCTYPE html>
 <html lang='en'>
 <head>
-  <title>W3C/OGC Maps for the Web workshop -- 24 Sep 2020</title>
-  <link type="text/css" rel="STYLESHEET" href="https://www.w3.org/StyleSheets/base.css">
-  <link type="text/css" rel="STYLESHEET" href="https://www.w3.org/StyleSheets/public.css">
-  <link type="text/css" rel="STYLESHEET" href="https://www.w3.org/2004/02/minutes-style.css">
-  <meta content="W3C/OGC Maps for the Web workshop" name="Title">  
   <meta charset="utf-8">
+  <title>W3C/OGC Maps for the Web workshop -- 24 Sep 2020</title>
+  <link rel="stylesheet" href="https://www.w3.org/StyleSheets/base.css">
+  <link rel="stylesheet" href="https://www.w3.org/StyleSheets/public.css">
+  <link rel="stylesheet" href="https://www.w3.org/2004/02/minutes-style.css">
+  <link rel="stylesheet" href="style.css">
+  <meta content="W3C/OGC Maps for the Web workshop" name="Title">  
 </head>
 
 <body>

--- a/supporting-material-uploads/minutes/style.css
+++ b/supporting-material-uploads/minutes/style.css
@@ -1,0 +1,33 @@
+body {
+  background-color: #eaeaff;
+  max-width: 50em;
+  margin: 0 auto;
+  padding-bottom: 1em;
+}
+
+.irc {
+  background-color: #c2c2dc;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    color: #d8e0ff;
+    background: #002020;
+  }
+
+  h1, h2, h3, h4, h5, h6, .irc {
+    background: hsla(0, 0%, 0%, 0.3);
+  }
+
+  a {
+    background: hsla(0,0%,0%,0.15);
+  }
+
+  a:link {
+      color: #68f;
+  }
+
+  a:visited {
+      color: #a5d;
+  }
+}


### PR DESCRIPTION
@tguild thoughts?

Set a `max-width` and center body for readability.

This also re-uses styles from maps4html.org:

Light mode:

<img width="400" src="https://user-images.githubusercontent.com/26493779/94371167-b4300c00-00f4-11eb-9828-6c75f35cad8e.png" alt="Light mode">

Dark mode:

<img width="400" src="https://user-images.githubusercontent.com/26493779/94371172-b72afc80-00f4-11eb-9f1c-6d791c0e6c4d.png" alt="Dark mode">
