### PR TITLE
Add group's ID to w3c.json

### DIFF
--- a/w3c.json
+++ b/w3c.json
@@ -1,4 +1,5 @@
 {
+  "group": 70543,
   "contacts": ["prushforth", "AmeliaBR", "tguild"],
   "repo-type": "workshop"
 }


### PR DESCRIPTION
Adding the maps4html group ID `70543` (derived from https://respec.org/w3c/groups/) in a [`group` field](https://w3c.github.io/w3c.json.html#group) to w3c.json.

I have already made changes to other repositories that have a w3c.json file in the commits:

https://github.com/Maps4HTML/Maps4HTML.github.io/commit/ab39d5017940abefae785f2f89394c14ff80dcd5
https://github.com/Maps4HTML/Maps4HTML-CG-Charter/commit/18839b991b97f087b1b68b0a32345554ea30561d
https://github.com/Maps4HTML/MapML/commit/0aaac9d087839862ee34a0d5c42ded4ce2fd1caa
https://github.com/Maps4HTML/MapML-Proposal/commit/0061363be99c678e4ac0ec8773edec86cd32b17b
https://github.com/Maps4HTML/Web-Map-Custom-Element/commit/4faec8dbd3ca8ead4d463a03b161f396fba54008
https://github.com/Maps4HTML/HTML-Map-Element-UseCases-Requirements/commit/38bbce3eee66eca7cc5bfbe859403abe0089fe82