### PR TITLE
Fix source destination to "focus ring example" image resource

### DIFF
--- a/supporting-material-uploads/presentations/Nic_Chan/index.html
+++ b/supporting-material-uploads/presentations/Nic_Chan/index.html
@@ -177,7 +177,7 @@
       <h2>Focus Visible</h2>
       <img
         class="side"
-        src="./assets/focus-ring-example.png"
+        src="./assets/focus-ring-example.PNG"
         alt="Google Maps and the default Chrome focus ring"
       />
       <p class="text--callout">7/11 tools failed</p>


### PR DESCRIPTION
[This slide](https://www.w3.org/2020/maps/supporting-material-uploads/presentations/Nic_Chan/index.html?full#slide-focus-visible) fails to load an image resource because it points to the image resource with a lower-case file extension:

https://www.w3.org/2020/maps/supporting-material-uploads/presentations/Nic_Chan/assets/focus-ring-example.png

changing to: upper-case
https://www.w3.org/2020/maps/supporting-material-uploads/presentations/Nic_Chan/assets/focus-ring-example.PNG