### PR TITLE
Copy changes to reflect that the workshop has already occurred

### DIFF
--- a/_includes/register-cta.html
+++ b/_includes/register-cta.html
@@ -1,15 +1,7 @@
 <aside class="box box-register box-emphasis" id="register-now">
-    <h2 class="cta">
-      Registered Participants!
-    </h2>
-    <p>
-      Check your email for the calendar file with Zoom video-conference links.
-    </p>
-    <h2 class="cta">
-      Not registered?
-    </h2>
-    <p>
-      Video sessions will be posted on YouTube with continued discussion happening on the
-      <a href="https://discourse.wicg.io/c/web-mapping/22">WICG Discourse</a>.
-    </p>
+  <p>
+    Session videos, transcripts, and supporting material are available in the <a href="{{ relBase }}/agenda">agenda</a>
+    with continued discussion happening on the
+    <a href="https://discourse.wicg.io/c/web-mapping/22">WICG Discourse</a>.
+  </p>
 </aside>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -35,7 +35,6 @@
     </main>
     {% include register-cta.html %}
     {% include host.html %}
-    {% include sponsors.html %}
     {% include footer.html %}
     <script src="{{ relBase }}/assets/js/script.js"></script>
   </body>

--- a/agenda.html
+++ b/agenda.html
@@ -18,7 +18,7 @@ layout: default
   </p>
 </div>
 <p>
-  The workshop series will consist of scheduled video conference sessions
+  The workshop series consists of scheduled video conference sessions
   (presentations, panel discussions, and in-depth breakout discussions)
   and asynchronous written discussion.
 </p>
@@ -46,14 +46,9 @@ layout: default
 <div class="info">
   <p>
   Due to risks associated with global travel and the spread COVID-19,
-  the Maps for the Web workshop series in 2020 will be online only,
+  the Maps for the Web workshop series in 2020 was online only,
   using a distributed, asynchronous model to encourage in-depth participation
   regardless of time zones.
-  </p>
-  <p>
-  This is a new format for a W3C or OGC Workshop,
-  and we're still finalizing the details of what it will look like.
-  Suggestions from registered participants are welcome.
   </p>
 </div>
 <!--
@@ -259,25 +254,9 @@ layout: default
     </p>
   </dd>
 </dl>
-<h3 id="tools">
-  Tools
-</h3>
-<div class="info">
-  <p>
-    We're still collecting information on the different options
-    for remote collaboration tools.
-    Your feedback is welcome!
-    We especially want to ensure that the chosen tools are accessible to all.
-  </p>
-  <p>
-    Add suggestions to our discussion issues
-    for <a href="https://github.com/Maps4HTML/Maps4HTML-Workshop-2020/issues/39">video conferencing and video hosting</a>,
-    or <a href="https://github.com/Maps4HTML/Maps4HTML-Workshop-2020/issues/40">text-based forums</a>.
-  </p>
-</div>
-<h4 id="minutes">
+<h3 id="minutes">
   Maintaining records
-</h4>
+</h3>
 <p>
   All session organizers are expected to create records
   of what was discussed,

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@ permalink: "/"
   <p>
     This workshop series was originally planned as an in-person event in Montreal.
     Due to risks associated with global travel and the spread of COVID-19,
-    the Maps for the Web workshop in 2020 will be online only,
+    the Maps for the Web workshop in 2020 was online only,
     spread out over a month of video presentations and asynchronous discussion.
   </p>
   <p>
@@ -67,8 +67,8 @@ permalink: "/"
 
 <h2 id="scope">Scope of the Workshops</h2>
 <p>
-  The workshop series is specifically about the standardization of dynamic, 
-  interactive maps as a first-class native component in the browser or other 
+  The workshop series is specifically about the standardization of dynamic,
+  interactive maps as a first-class native component in the browser or other
   applications built using the Web platform.
 </p>
 <p>

--- a/supporting-material.html
+++ b/supporting-material.html
@@ -9,10 +9,10 @@ description: >-
 
 <div class="info">
   <p>
-   Workshop particpants are invited to join the 
+   Workshop particpants are invited to join the
    <a href="https://gitter.im/Maps4HTML/W3C-OGC-Workshop-Maps-For-Web">
    workshop gitter chat</a> to exchange information with other participants,
-   and the program committee. You'll need either a GitHub, GitLab or Twitter 
+   and the program committee. You'll need either a GitHub, GitLab or Twitter
    account to join.
   </p>
 </div>
@@ -21,25 +21,6 @@ description: >-
   This page collects background reading material
   from and for workshop participants.
 </p>
-
-<div class="info">
-  <p>
-    Participants are invited to submit summaries of their projects and priorities,
-    for review by others before the event.
-    See the <a href="{{ relBase }}/call-for-participation">call for participation</a> for more.
-  </p>
-  <p>
-    In addition to the formal position statements from individuals and organizations,
-    the organizers welcome suggestions of links to
-    related standards, research, reports,
-    proposals and explainers,
-    software projects, or datasets.
-    These can be submitted by email to the
-    <a href="{{ relBase }}/call-for-participation#program-committee">program committee</a>,
-    or by <a href="https://github.com/Maps4HTML/Maps4HTML-Workshop-2020/issues">filing a GitHub issue</a>
-    on the workshop series website.
-  </p>
-</div>
 
 <h2 id="position-statements">Participant and Position Statements</h2>
 


### PR DESCRIPTION
One question - Should we remove Potential Topics from the homepage? I think the need for them has passed.
